### PR TITLE
chore: remove npm prune from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ node_js:
   - '7'
   - '6'
   - '4'
-before_script:
-  - npm prune
 after_success:
   - npm run semantic-release
 branches:


### PR DESCRIPTION
This package uses yarn, so `npm prune` is not needed.